### PR TITLE
feat: リンクリストのドラッグ&ドロップ並び替え機能

### DIFF
--- a/frontend/app/toppage/page.tsx
+++ b/frontend/app/toppage/page.tsx
@@ -47,6 +47,7 @@ export default function TopPage() {
           <UrlForm onSubmit={handleSubmit} />
           <UrlList
             urls={urls}
+            setUrls={setUrls}
             onReset={handleReset}
             onDelete={handleDelete}
           />

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -37,8 +37,10 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-2 group relative pr-8 rounded-md transition-colors ${
-        isDragging ? 'bg-gray-100 dark:bg-gray-700' : 'hover:bg-gray-50 dark:hover:bg-gray-800'
+      className={`flex items-center gap-2 group relative pr-8 rounded-md transition-all duration-200 border-2 ${
+        isDragging 
+          ? 'bg-blue-100 dark:bg-blue-900 shadow-lg scale-105 border-blue-400 dark:border-blue-500' 
+          : 'border-transparent hover:bg-blue-50 dark:hover:bg-blue-950 hover:shadow-md hover:scale-[1.02] hover:border-blue-300 dark:hover:border-blue-700'
       }`}
     >
       <div
@@ -46,7 +48,7 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
         {...attributes}
         {...listeners}
       >
-        <DragIcon className="flex-shrink-0" />
+        <DragIcon className="flex-shrink-0 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors" />
         <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
           {`[${url.title}](${url.url})`}
         </pre>

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -1,8 +1,61 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { type OutputUrlData } from '@/lib/types';
+
 interface MarkdownDisplayProps {
   isEmpty: boolean;
-  urls: { id: string; url: string }[];
+  urls: OutputUrlData[];
   onDelete: (id: string) => void;
 }
+
+interface SortableItemProps {
+  id: string;
+  url: OutputUrlData;
+  onDelete: (id: string) => void;
+}
+
+const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 group relative pr-8"
+    >
+      <button
+        className="cursor-grab active:cursor-grabbing p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+        {...attributes}
+        {...listeners}
+      >
+        <DragIcon />
+      </button>
+      <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
+        {`[${url.title}](${url.url})`}
+      </pre>
+      <button
+        onClick={() => onDelete(url.id)}
+        className="absolute right-0 hover:bg-red-100 dark:hover:bg-red-900 rounded p-1.5 transition-colors duration-200"
+        title="削除"
+      >
+        <DeleteIcon />
+      </button>
+    </div>
+  );
+};
 
 export const MarkdownDisplay = ({ isEmpty, urls, onDelete }: MarkdownDisplayProps) => {
   return (
@@ -14,18 +67,12 @@ export const MarkdownDisplay = ({ isEmpty, urls, onDelete }: MarkdownDisplayProp
         ) : (
           <div className="space-y-2">
             {urls.map((url) => (
-              <div key={url.id} className="flex items-center gap-2 group relative pr-8">
-                <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
-                  {`[${url.url}](${url.url})`}
-                </pre>
-                <button
-                  onClick={() => onDelete(url.id)}
-                  className="absolute right-0 hover:bg-red-100 dark:hover:bg-red-900 rounded p-1.5 transition-colors duration-200"
-                  title="削除"
-                >
-                  <DeleteIcon />
-                </button>
-              </div>
+              <SortableItem
+                key={url.id}
+                id={url.id}
+                url={url}
+                onDelete={onDelete}
+              />
             ))}
           </div>
         )}
@@ -49,5 +96,27 @@ const DeleteIcon = () => (
   >
     <path d="M18 6L6 18" />
     <path d="M6 6l12 12" />
+  </svg>
+);
+
+const DragIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="text-gray-400"
+  >
+    <circle cx="9" cy="5" r="1" />
+    <circle cx="9" cy="12" r="1" />
+    <circle cx="9" cy="19" r="1" />
+    <circle cx="15" cy="5" r="1" />
+    <circle cx="15" cy="12" r="1" />
+    <circle cx="15" cy="19" r="1" />
   </svg>
 ); 

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -37,10 +37,10 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-2 group relative pr-8 rounded-md transition-all duration-200 border-2 ${
+      className={`flex items-center gap-2 group relative pr-8 rounded-md transition-all duration-200 border ${
         isDragging 
-          ? 'bg-blue-100 dark:bg-blue-900 shadow-lg scale-105 border-blue-400 dark:border-blue-500' 
-          : 'border-transparent hover:bg-blue-50 dark:hover:bg-blue-950 hover:shadow-md hover:scale-[1.02] hover:border-blue-300 dark:hover:border-blue-700'
+          ? 'bg-gray-100 dark:bg-gray-700 shadow-md border-gray-300 dark:border-gray-600' 
+          : 'border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-200 dark:hover:border-gray-700'
       }`}
     >
       <div
@@ -48,7 +48,7 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
         {...attributes}
         {...listeners}
       >
-        <DragIcon className="flex-shrink-0 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors" />
+        <DragIcon className="flex-shrink-0 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
         <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
           {`[${url.title}](${url.url})`}
         </pre>

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -25,7 +25,10 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
   } = useSortable({ id });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Transform.toString(transform && {
+      ...transform,
+      x: 0, // X軸の移動を0に固定して横方向の動きを制限
+    }),
     transition,
     opacity: isDragging ? 0.5 : 1,
   };

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -37,18 +37,20 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-2 group relative pr-8"
+      className={`flex items-center gap-2 group relative pr-8 rounded-md transition-colors ${
+        isDragging ? 'bg-gray-100 dark:bg-gray-700' : 'hover:bg-gray-50 dark:hover:bg-gray-800'
+      }`}
     >
-      <button
-        className="cursor-grab active:cursor-grabbing p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+      <div
+        className="cursor-grab active:cursor-grabbing flex-1 flex items-center gap-2 py-2 px-2"
         {...attributes}
         {...listeners}
       >
-        <DragIcon />
-      </button>
-      <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
-        {`[${url.title}](${url.url})`}
-      </pre>
+        <DragIcon className="flex-shrink-0" />
+        <pre className="whitespace-pre-wrap break-all font-mono text-sm text-gray-700 dark:text-gray-300 flex-1">
+          {`[${url.title}](${url.url})`}
+        </pre>
+      </div>
       <button
         onClick={() => onDelete(url.id)}
         className="absolute right-0 hover:bg-red-100 dark:hover:bg-red-900 rounded p-1.5 transition-colors duration-200"
@@ -102,7 +104,7 @@ const DeleteIcon = () => (
   </svg>
 );
 
-const DragIcon = () => (
+const DragIcon = ({ className = "" }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="16"
@@ -113,7 +115,7 @@ const DragIcon = () => (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
-    className="text-gray-400"
+    className={`text-gray-400 ${className}`}
   >
     <circle cx="9" cy="5" r="1" />
     <circle cx="9" cy="12" r="1" />

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -39,8 +39,8 @@ const SortableItem = ({ id, url, onDelete }: SortableItemProps) => {
       style={style}
       className={`flex items-center gap-2 group relative pr-8 rounded-md transition-all duration-200 border ${
         isDragging 
-          ? 'bg-gray-100 dark:bg-gray-700 shadow-md border-gray-300 dark:border-gray-600' 
-          : 'border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-200 dark:hover:border-gray-700'
+          ? 'bg-gray-100 dark:bg-gray-700 shadow-md border-gray-400 dark:border-gray-500' 
+          : 'border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600'
       }`}
     >
       <div

--- a/frontend/components/toppage/markdown-display.tsx
+++ b/frontend/components/toppage/markdown-display.tsx
@@ -64,11 +64,11 @@ export const MarkdownDisplay = ({ isEmpty, urls, onDelete }: MarkdownDisplayProp
   return (
     <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 shadow-lg border border-gray-200 dark:border-gray-700">
       <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-2">マークダウン</h3>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-96 overflow-y-auto">
         {isEmpty ? (
           <p className="text-gray-500 dark:text-gray-400">登録されたURLはありません</p>
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-2 relative">
             {urls.map((url) => (
               <SortableItem
                 key={url.id}

--- a/frontend/components/toppage/url-list.tsx
+++ b/frontend/components/toppage/url-list.tsx
@@ -2,12 +2,46 @@ import { type OutputUrlData, type UrlListProps } from '@/lib/types';
 import { useState } from 'react';
 import { MarkdownDisplay } from './markdown-display';
 import { MarkdownPreview } from './markdown-preview';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 
-export const UrlList = ({ urls, onReset, onDelete }: UrlListProps) => {
+export const UrlList = ({ urls, setUrls, onReset, onDelete }: UrlListProps) => {
   const [copySuccess, setCopySuccess] = useState(false);
+  
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
 
   const formatUrlToMarkdown = (url: OutputUrlData) => {
     return `[${url.title}](${url.url})  `;
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id) {
+      setUrls((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id);
+        const newIndex = items.findIndex((item) => item.id === over?.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
   };
 
   const markdownText = urls.map(formatUrlToMarkdown).join('\n');
@@ -61,11 +95,22 @@ export const UrlList = ({ urls, onReset, onDelete }: UrlListProps) => {
         )}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <MarkdownDisplay
-          isEmpty={urls.length === 0}
-          urls={urls}
-          onDelete={onDelete}
-        />
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={urls.map(url => url.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <MarkdownDisplay
+              isEmpty={urls.length === 0}
+              urls={urls}
+              onDelete={onDelete}
+            />
+          </SortableContext>
+        </DndContext>
         <MarkdownPreview
           markdownText={markdownText}
           isEmpty={urls.length === 0}

--- a/frontend/components/toppage/url-list.tsx
+++ b/frontend/components/toppage/url-list.tsx
@@ -11,6 +11,7 @@ import {
   useSensors,
   DragEndEvent,
 } from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import {
   arrayMove,
   SortableContext,
@@ -99,6 +100,7 @@ export const UrlList = ({ urls, setUrls, onReset, onDelete }: UrlListProps) => {
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}
         >
           <SortableContext
             items={urls.map(url => url.id)}

--- a/frontend/components/toppage/url-list.tsx
+++ b/frontend/components/toppage/url-list.tsx
@@ -11,7 +11,7 @@ import {
   useSensors,
   DragEndEvent,
 } from '@dnd-kit/core';
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import { restrictToListBounds } from '@/lib/dnd-modifiers';
 import {
   arrayMove,
   SortableContext,
@@ -100,7 +100,7 @@ export const UrlList = ({ urls, setUrls, onReset, onDelete }: UrlListProps) => {
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis]}
+          modifiers={[restrictToListBounds]}
         >
           <SortableContext
             items={urls.map(url => url.id)}

--- a/frontend/lib/dnd-modifiers.ts
+++ b/frontend/lib/dnd-modifiers.ts
@@ -1,0 +1,38 @@
+import { Modifier } from '@dnd-kit/core';
+
+export const restrictToListBounds: Modifier = ({
+  transform,
+  draggingNodeRect,
+  containerNodeRect,
+}) => {
+  if (!draggingNodeRect || !containerNodeRect) {
+    return transform;
+  }
+
+  const containerTop = containerNodeRect.top;
+  const containerBottom = containerNodeRect.bottom;
+  const itemHeight = draggingNodeRect.height;
+  
+  // ドラッグ中の要素の現在の位置
+  const currentTop = draggingNodeRect.top + transform.y;
+  const currentBottom = currentTop + itemHeight;
+  
+  // リストの境界を超えないように制限
+  let restrictedY = transform.y;
+  
+  // 上端の制限
+  if (currentTop < containerTop) {
+    restrictedY = containerTop - draggingNodeRect.top;
+  }
+  
+  // 下端の制限
+  if (currentBottom > containerBottom) {
+    restrictedY = containerBottom - draggingNodeRect.bottom;
+  }
+  
+  return {
+    ...transform,
+    y: restrictedY,
+    x: 0, // 横方向の移動も制限
+  };
+};

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -13,6 +13,7 @@ export interface OutputUrlData {
 // コンポーネントのProps型
 export interface UrlListProps {
   urls: OutputUrlData[];  // 表示用のデータはOutputUrlData
+  setUrls: React.Dispatch<React.SetStateAction<OutputUrlData[]>>;
   onReset: () => void;
   onDelete: (id: string) => void;
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.0.0",
         "cheerio": "^1.0.0-rc.12",
         "next": "15.3.2",
@@ -52,6 +55,59 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.0.0",
@@ -82,6 +83,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,12 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-query": "^5.0.0",
+    "cheerio": "^1.0.0-rc.12",
     "next": "15.3.2",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
-    "react-markdown": "^10.1.0",
-    "cheerio": "^1.0.0-rc.12",
-    "@tanstack/react-query": "^5.0.0"
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.0.0",


### PR DESCRIPTION
## Summary
- ドラッグ&ドロップでURLリストの並び替えが可能に
- 並び替えた順序でマークダウンが生成される

## 実装内容
- `@dnd-kit/sortable`ライブラリを使用したドラッグ&ドロップ機能
- 各リストアイテムにドラッグハンドル（6点アイコン）を追加
- 並び替え後の順序を状態として保持
- マークダウン出力も並び替え後の順序を反映

## 関連Issue
Closes #6

## Test plan
- [ ] URLを複数登録する
- [ ] ドラッグハンドルを使ってリストアイテムを並び替える
- [ ] 並び替え後のマークダウンプレビューが正しく更新されることを確認
- [ ] マークダウンをコピーして、並び替え後の順序が保持されていることを確認
- [ ] キーボード操作でも並び替えができることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)