### PR TITLE
fix: 日本語サイトのメタタイトル文字化け問題を解決

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,42 @@ Branch names should follow this format:
 - Separate words with hyphens (_)
 - Always include issue number when available
 - Keep descriptions concise and meaningful
+
+## Pull Request (PR) Guidelines
+
+### Issue Number Format in PR Descriptions
+When referencing issues in PR descriptions, use the following format:
+
+**Correct format**: `issue #<number> <description>`
+- ✅ `issue #12 の対応として、ITmediaなどの日本語サイトでメタタイトルが文字化けする問題を解決`
+- ✅ `issue #8 の対応として、アプリ名をLLShareに変更`
+
+**Incorrect format**: `issue#<number>` (missing space)
+- ❌ `issue#12の対応として...`
+- ❌ `issue#8の対応として...`
+
+### PR Description Template
+```markdown
+## Summary
+- issue #<number> の対応として、[問題の説明]
+- [実装した機能や変更の概要]
+
+## 実装内容
+- [変更点1]
+- [変更点2]
+- [変更点3]
+
+## テスト結果
+- ✅ [テストケース1]: [結果]
+- ✅ [テストケース2]: [結果]
+
+## Test plan
+- [ ] [テスト項目1]
+- [ ] [テスト項目2]
+```
+
+### Important Notes
+- Always include the issue number with a space after the hash symbol
+- Use Japanese for descriptions when appropriate
+- Include test results and test plans
+- Reference specific technical changes made

--- a/frontend/app/api/meta/route.ts
+++ b/frontend/app/api/meta/route.ts
@@ -5,6 +5,67 @@ export const runtime = 'edge';
 // キャッシュの設定
 export const revalidate = 3600; // 1時間キャッシュ
 
+// エンコーディング検出関数
+function detectEncoding(url: string, contentType: string | null): string {
+  // Content-Typeヘッダーからcharsetを取得
+  if (contentType) {
+    const charsetMatch = contentType.match(/charset=([^;]+)/i);
+    if (charsetMatch) {
+      return charsetMatch[1].toLowerCase();
+    }
+  }
+
+  // サイト固有のエンコーディング設定
+  const siteEncodings: Record<string, string> = {
+    'itmedia.co.jp': 'shift_jis',
+    'nikkei.com': 'shift_jis',
+    'sankei.com': 'shift_jis',
+    'mainichi.jp': 'shift_jis',
+    'yomiuri.co.jp': 'shift_jis',
+    'asahi.com': 'shift_jis'
+  };
+
+  // URLのドメインをチェック
+  try {
+    const domain = new URL(url).hostname;
+    for (const [siteDomain, encoding] of Object.entries(siteEncodings)) {
+      if (domain.includes(siteDomain)) {
+        return encoding;
+      }
+    }
+  } catch {
+    // URL解析に失敗した場合はデフォルトを使用
+  }
+
+  // デフォルトはUTF-8
+  return 'utf-8';
+}
+
+// HTMLテキストを適切なエンコーディングでデコード
+async function fetchAndDecodeHtml(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36' },
+  });
+
+  // ArrayBufferとして取得
+  const arrayBuffer = await response.arrayBuffer();
+  
+  // エンコーディングを検出
+  const contentType = response.headers.get('content-type');
+  const encoding = detectEncoding(url, contentType);
+  
+  // TextDecoderでデコード
+  try {
+    const decoder = new TextDecoder(encoding);
+    return decoder.decode(arrayBuffer);
+  } catch (error) {
+    // エンコーディングに失敗した場合はUTF-8でフォールバック
+    console.warn(`Failed to decode with ${encoding}, falling back to UTF-8:`, error);
+    const decoder = new TextDecoder('utf-8');
+    return decoder.decode(arrayBuffer);
+  }
+}
+
 export async function GET(request: NextRequest) {
   const urlParam = request.nextUrl.searchParams.get('url');
 
@@ -13,10 +74,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const response = await fetch(urlParam, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36' },
-    });
-    const html = await response.text();
+    const html = await fetchAndDecodeHtml(urlParam);
 
     if (!html) {
       return new Response(JSON.stringify({ title: urlParam }), { status: 200 });
@@ -48,7 +106,20 @@ export async function GET(request: NextRequest) {
       }
     );
   } catch (error) {
-    console.error(error);
-    return new Response(JSON.stringify({ error: 'Failed to fetch meta title' }), { status: 500 });
+    console.error('Error fetching meta title:', error);
+    
+    // エラーの詳細情報を含める（開発環境でのみ）
+    const isDevelopment = process.env.NODE_ENV === 'development';
+    const errorMessage = isDevelopment && error instanceof Error 
+      ? `Failed to fetch meta title: ${error.message}`
+      : 'Failed to fetch meta title';
+    
+    return new Response(
+      JSON.stringify({ 
+        error: errorMessage,
+        title: urlParam // エラー時でもURLをタイトルとして返す
+      }), 
+      { status: 500 }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- issue #12 の対応として、ITmediaなどの日本語サイトでメタタイトルが文字化けする問題を解決
- エンコーディング検出機能とTextDecoderを使用したデコード処理を実装
- Shift_JISサイトとUTF-8サイトの両方で正常に動作

## 実装内容
- **エンコーディング検出関数**: Content-TypeヘッダーからcharsetとURL-based detection
- **TextDecoderによるデコード**: ArrayBufferから適切なエンコーディングでデコード
- **サイト固有設定**: ITmedia、日経、産経、毎日、読売、朝日にShift_JIS設定
- **フォールバック機能**: エンコーディング失敗時にUTF-8でフォールバック
- **改善されたエラーハンドリング**: 開発環境での詳細エラー情報とURLフォールバック

## テスト結果
- ✅ ITmedia: `LINEヤフー、生成AI活用を義務化　「任意の会議は出席せず、AI議事録で把握」など`
- ✅ 日経新聞: `日本経済新聞 - ニュース・速報 最新情報`
- ✅ 産経新聞: `産経新聞：産経ニュース`
- ✅ GitHub(UTF-8): `GitHub · Build and ship software on a single, collaborative platform`

## Test plan
- [ ] 各種日本語サイトでのメタタイトル取得テスト
- [ ] UTF-8サイトでの既存機能確認
- [ ] エラーハンドリングの動作確認
- [ ] パフォーマンステスト

🤖 Generated with [Claude Code](https://claude.ai/code)